### PR TITLE
revise ssh-agent now that exercise is less about encrypting keys

### DIFF
--- a/class/exercises/ssh-agent/objectives.md
+++ b/class/exercises/ssh-agent/objectives.md
@@ -1,6 +1,7 @@
 At the end of this exercise students should know...
 
-  - The importance of setting a password on your SSH key
-  - How to overcome the inconvenience of having to constantly type your SSH key password
-   - How to add keys to SSH agent
-
+- What ssh-agent is.
+- How to add keys to it.
+- How to list keys in it.
+- How to forward ssh-agent state in a ssh session with a command line flag.
+- How to configure ~/.ssh/config to enable forwarding for specific hosts

--- a/class/exercises/ssh-agent/overview.md
+++ b/class/exercises/ssh-agent/overview.md
@@ -1,9 +1,42 @@
 # WHAT IS SSH-AGENT?
 
-Recall that in asymmetric cryptography possession of the private key is proof of identity. That means if anyone were ever to obtain your private key they could digitally impersonate you. To prevent the private key file from being a single point of failure and high value target it's not uncommon for private key files to be protected with a pass phrase. This protects your private key in the event that it is ever stolen or compromised and is a form of two factor authentication: the first factor being something you have (the private key file) and the second factor being something you know (the pass phrase).
+In the previous exercise, we showed how to encrypt a private key with a user
+supplied passphrase. We also noted that each subsequent use of said key will
+require decryption. In practice, this can be onerous for day-to-day development.
 
-The benefits of protecting your private key with a pass phrase are clear, but in everyday usage this can be a large inconvenience. For the pass phrase to be effective it must be significantly long and complex, which makes typing it every time you push code or access a machine a constant source of frustration. We can keep our private key secure and our daily routines unencumbered by using SSH Agent.
+Enter ssh-agent, a tool which can store the unencrypted versions of your private
+keys in memory, and communicate directly with ssh-based tools to provide them
+automatically. Most modern operating systems ship with some form of ssh-agent,
+which should run in the background after you log in, and terminate when you log
+out.
 
-SSH Agent is a program that keeps track of a user's various private keys and interfaces with SSH to provide them when asked for (vs just reading them directly from the file system) if a key is protected with a pass phrase SSH Agent is capable of prompting the user for it. Keys can be added to SSH Agent with the command `ssh-add -K /path/to/key`
+You can add a key to ssh-agent any time with the following command:
 
-At first pass it may seem that SSH agent isn't doing much of anything in the way of simplifying regular private key use, however the benefit of SSH Agent is its ability to save state across a user's entire session. In practice that means SSH Agent can be started when a user initially logs into a machine and remain running the background, effectively allowing a user to unlock their keys one time and continue using them without be prompted for a password until they log off or restart the machine. Further, this state can be *forwarded* to machines the user connects to using SSH's `-T` option. This allows users to avoid copying their private keys on machines they regularly SSH onto, making things like version control access from remote servers easier. Further, SSH Agent removes the need to use SSH's `-i` option as it will automatically loop through all of your private keys until it's able to establish a successful connection or it runs out of keys. Configuring SSH Agent to run on startup is different across platforms so Google for the best way to do this depending on your development machine's architecture.
+```
+ssh-add /path/to/key
+```
+
+Running `ssh-add` without arguments will automatically attempt to add all of
+these default keys: `~/.ssh/id_rsa`, `~/.ssh/id_dsa` and `~/.ssh/identity`.
+
+You can list all keys currently stored in your ssh-agent with the following:
+
+```
+ssh-add -L
+```
+
+Not only does ssh-agent effectively allow a user to unlock their keys one time
+and continue using them without being prompted for their passphrase, this state
+can be *forwarded* to remote machines the user connects to using SSH's `-T`
+option.
+
+This means users need not copy their private keys to machines they regularly SSH
+into. A common example of this would be a production server which is expected to
+have access to a private version controlled repository. Rather than configuring
+the server with a "deploy key", the server can perform the checkout as though it
+were the user actually running the deployment.
+
+Further, ssh-agent obviates the need to specify a private key when connecting to
+a remote machine (e.g. `ssh -i /path/to/key`), as it will automatically loop
+through all of your private keys until it's able to establish a successful
+connection (or it runs out of keys).

--- a/class/exercises/ssh-agent/solution/config
+++ b/class/exercises/ssh-agent/solution/config
@@ -1,0 +1,2 @@
+Host *.learn-deployment.com
+  ForwardAgent yes

--- a/class/instructor/overview.md
+++ b/class/instructor/overview.md
@@ -7,12 +7,6 @@ should require that the user's keypair be protected by a passphrase:
 If students do not have a public/private keypair, they can follow this guide:
 https://help.github.com/articles/generating-ssh-keys/
 
-If students *do* have a public/private keypair but it isn't protected by a
-passphrase they can add one with the following command:
-```
-ssh-keygen -p -f ~/.ssh/id_rsa
-```
-
 The instructor should prepare the ansible configuration in this folder to grant
 all students access to a server. This should **NOT** be run before the first
 exercise begins.
@@ -75,13 +69,19 @@ done.
 ## ssh-key-passphrases
 
 Students will now learn about passphrases, how to add them to their keys if
-they don't have them, and how they are an instance of two factor authentication.
+they don't have them, and how they are a type of two factor authentication.
 This will lead into dealing with ssh-agent.
 
 ## ssh-agent
 
-Students now understand the basic usage of private keys. Now, we check to see if
-students used a passphrase
+Students now understand the basic usage of private keys. We'll now make managing
+them easier to deal with by adding to/listing the keys in our agent.
+
+We can check if ssh-agent is running by inspecting the environment variable
+$SSH_AUTH_SOCK, or using `ssh -T git@github.com` for accounts with a public
+key associated with a user (the flag `-T` prevents ssh from trying to create
+an interactive shell, which github will not provide--it has nothing to do with
+agent forwarding).
 
 ## your-server
 


### PR DESCRIPTION
This is a pretty heavy revision. I kept looking at the ssh-agent one and feeling like it focused too much on passphrases. The PR you just merged picked up that content and this one expands a bit more on what you already had.