### PR TITLE
Display "cd <exercise directory>" instructions

### DIFF
--- a/learn/lib/choose.js
+++ b/learn/lib/choose.js
@@ -27,5 +27,6 @@ module.exports = function (exercisesDir, exercises) {
       wrench.copyDirSyncRecursive(src, dest);
       console.log('Done.');
     }
+    console.log(`Type "cd ${path.basename(dest)}" (<enter>) to enter this exercise's directory.`);
   };
 };


### PR DESCRIPTION
The paths shown in the actual exercise examples are written such that they assume the reader is _in_ that exercise directory. This intruction ensures that the reader knows that will be the case by telling them to cd to the directory.